### PR TITLE
Fix the permission for the github actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      issues: write
+      contents: write
 
     steps:
 


### PR DESCRIPTION
This commit fixes the permission required for the github actions to push the content to gh-pages.