### PR TITLE
Add update board functionality

### DIFF
--- a/pytrello2/board.py
+++ b/pytrello2/board.py
@@ -68,3 +68,16 @@ class BoardManager:
         """
         lists = self.client.get(f"boards/{board_id}/lists/")
         return [List(list) for list in lists]
+
+    def update_board(self, board_id, **kwargs):
+        """
+        Updates a board with the given ID.
+
+        Parameters:
+            - board_id (str): The unique identifier of the board.
+            - kwargs: Additional options for the board.
+        """
+	    data = {}
+        data.update(kwargs)
+        board = self.client.put(f"boards/{board_id}/", data)
+        return Board(board)

--- a/pytrello2/board.py
+++ b/pytrello2/board.py
@@ -77,7 +77,7 @@ class BoardManager:
             - board_id (str): The unique identifier of the board.
             - kwargs: Additional options for the board.
         """
-	    data = {}
+        data = {}
         data.update(kwargs)
         board = self.client.put(f"boards/{board_id}/", data)
         return Board(board)

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -94,3 +94,16 @@ def test_get_lists_on_board(mock_http_client):
         assert list.id == mock_data["id"]
         assert list.name == mock_data["name"]
     mock_http_client.get.assert_called_once_with("boards/test_board_id/lists/")
+
+
+# Test for update_board method
+def test_update_board(mock_http_client):
+    board_data = load_mock_data(BOARD_MOCK_DATA)
+    mock_http_client.put.return_value = board_data
+
+    board_manager = BoardManager(mock_http_client)
+    board = board_manager.update_board("test_board_id")
+
+    assert isinstance(board, Board)
+    assert board.id == board_data["id"]
+    mock_http_client.put.assert_called_once_with("boards/test_board_id/", {})


### PR DESCRIPTION
This commit adds the update board functionality.
The tests are also updated accordingly.

Signed-off-by: jessat <14183940+jessat@users.noreply.github.com>